### PR TITLE
Permalink changes (is that even possible?) related to #49

### DIFF
--- a/explore.md
+++ b/explore.md
@@ -21,7 +21,7 @@ title: Explore the Database
     <tbody>
         {% for species in site.data.mdd %}
             <tr>
-            <td><a href="#"><input type = "button" class="text-button" onclick = "fillSpeciesInfo(this)" id = "speciesID" value = "{{ species.id }}"></a></td>
+            <td><a href="#{{ species.id }}"><input type = "button" class="text-button" onclick = "fillSpeciesInfo(this)" id = "speciesID" value = "{{ species.id }}"></a></td>
             <td><i>{{ species.genus }}</i></td>
             <td><i>{{ species.specificEpithet }}</i></td>
             <td>{{ species.family | downcase | capitalize }}</td>

--- a/js/filter.js
+++ b/js/filter.js
@@ -209,7 +209,9 @@ function populateSpeciesInfo(results, speciesID) {
 
 function goPermalink(event) {
     let speciesId = speciesIdFor(document.location.href);
-    speciesId !== undefined && loadSpeciesById(speciesId);
+    if (speciesId !== undefined) {
+      loadSpeciesById(speciesId);
+    }
 }
 
 
@@ -602,7 +604,6 @@ function populateStats(event) {
 
 
 function createOrderTable(event) {
-    var data = "assets/data/mdd.csv";
     loadMDD(populateOrderTable);
 }
 

--- a/js/filter.js
+++ b/js/filter.js
@@ -46,6 +46,7 @@ function renderSpeciesPage(speciesData, permalink) {
   
   var specHead = document.createElement("h2");
   specHead.className = "species-head";
+  specHead.setAttribute("id", speciesData.id);
   var commonName = document.createElement("div");
   commonName.style.cssText = "font-size: 20px; color: grey; display: inline;";
   commonName.textContent = speciesData.mainCommonName;
@@ -199,8 +200,9 @@ function renderSpeciesPage(speciesData, permalink) {
 function populateSpeciesInfo(results, speciesID) {
   var speciesDataHits = results.data.filter(function(species) { return speciesID === species.id; }); 
   speciesDataHits.forEach(function(speciesData) {
-    let permalink = permalinkFor(document.location.href, speciesData);
-    document.location.replace(permalink);
+    let permalink = permalinkFor(document.location.href, speciesData); 
+    // https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
+    history.pushState({}, "", permalink);
     renderSpeciesPage(speciesData, permalink);
   });
 }

--- a/js/filter.js
+++ b/js/filter.js
@@ -206,8 +206,8 @@ function populateSpeciesInfo(results, speciesID) {
 }
 
 function goPermalink(event) {
-    let speciesId = speciesIdForPermalink(document.location.href);
-    speciesId || loadSpeciesById(speciesId);
+    let speciesId = speciesIdFor(document.location.href);
+    speciesId !== undefined && loadSpeciesById(speciesId);
 }
 
 

--- a/js/filter.js
+++ b/js/filter.js
@@ -1,6 +1,3 @@
----
----
-
 function filterFunc(event) {
     var inputString = event.target.value.toUpperCase().trim().split(' ');
     var rows = document.querySelector("#fullTable tbody").rows;
@@ -31,7 +28,8 @@ function filterFunc(event) {
     }
 
 
-function populateSpeciesInfo(results, speciesID, mddTable) {
+function renderSpeciesPage(speciesData, permalink) {
+
   var resultsDisplay = document.createElement("p");
   resultsDisplay.className = "box-paragraph";
   resultsDisplay.setAttribute("id", "speciesInfo");
@@ -42,167 +40,169 @@ function populateSpeciesInfo(results, speciesID, mddTable) {
      id.parentNode.removeChild(id);
   }
 
+  var specPermalink = document.createElement("a");
+  specPermalink.innerHTML = "<b>Species Permalink:</b> " + "<a href="+ permalink + ">" 
+  + permalink + "</a>";
+  
+  var specHead = document.createElement("h2");
+  specHead.className = "species-head";
+  var commonName = document.createElement("div");
+  commonName.style.cssText = "font-size: 20px; color: grey; display: inline;";
+  commonName.textContent = speciesData.mainCommonName;
+  var speciesName = speciesData.genus + " " + speciesData.specificEpithet
+  var specAuthority = "";
+  if (speciesData.authorityParentheses == 0) {
+      specAuthority = speciesData.authoritySpeciesAuthor + ", " + speciesData.authoritySpeciesYear;
+  } else {
+      specAuthority = "(" + speciesData.authoritySpeciesAuthor + ", " + speciesData.authoritySpeciesYear + ")";
+  }
+  //specAuthority.innerHTML = "<b>Authority:</b> " + speciesData.authoritySpeciesAuthor + ", " + speciesData.authoritySpeciesYear + "<br>";
+  specHead.innerHTML = speciesName.italics() + " " + specAuthority; 
+  //specHead.appendChild(commonName);
+  
+  var speciesCitation = document.createElement("p");
+  speciesCitation.innerHTML = "<b>Authority citation:</b> " + speciesData.authoritySpeciesCitation;
 
-  var speciesData = {};  
-  for (var i = 0; i < results.data.length; i ++) {
-      if (speciesID == results.data[i].id) {
-              speciesData = results.data[i];
-          }
-      }
-      document.location = permalink(document.URL, speciesData);
-      var specPermalink = document.createElement("a");
-      specPermalink.innerHTML = "<b>Species Permalink:</b> " + "<a href="+ permalink + ">" 
-      + permalink + "</a>";
-      
-      var specHead = document.createElement("h2");
-      specHead.className = "species-head";
-      var commonName = document.createElement("div");
-      commonName.style.cssText = "font-size: 20px; color: grey; display: inline;";
-      commonName.textContent = speciesData.mainCommonName;
-      var speciesName = speciesData.genus + " " + speciesData.specificEpithet
-      var specAuthority = "";
-      if (speciesData.authorityParentheses == 0) {
-          specAuthority = speciesData.authoritySpeciesAuthor + ", " + speciesData.authoritySpeciesYear;
-      } else {
-          specAuthority = "(" + speciesData.authoritySpeciesAuthor + ", " + speciesData.authoritySpeciesYear + ")";
-      }
-      //specAuthority.innerHTML = "<b>Authority:</b> " + speciesData.authoritySpeciesAuthor + ", " + speciesData.authoritySpeciesYear + "<br>";
-      specHead.innerHTML = speciesName.italics() + " " + specAuthority; 
-      //specHead.appendChild(commonName);
-      
-      var speciesCitation = document.createElement("p");
-      speciesCitation.innerHTML = "<b>Authority citation:</b> " + speciesData.authoritySpeciesCitation;
+  var authorityLink = document.createElement("p");
+  authorityLink.innerHTML = "<b>Authority publication link:</b> " + "<a href=" + speciesData.authoritySpeciesLink + " target=_blank>" + speciesData.authoritySpeciesLink + "</a>";
 
-      var authorityLink = document.createElement("p");
-      authorityLink.innerHTML = "<b>Authority publication link:</b> " + "<a href=" + speciesData.authoritySpeciesLink + " target=_blank>" + speciesData.authoritySpeciesLink + "</a>";
+  var otherCommonNames = document.createElement("p");
+  otherCommonNames.innerHTML = "<b>Other common names: </b>" + speciesData.otherCommonNames + "<br>";
 
-      var otherCommonNames = document.createElement("p");
-      otherCommonNames.innerHTML = "<b>Other common names: </b>" + speciesData.otherCommonNames + "<br>";
+  var originalName = document.createElement("p");
+  var firstName = "";
+  if (speciesData.originalNameCombination == "") {
+      firstName = "Name is as originally described.";
+  } else {
+      firstName = speciesData.originalNameCombination.split('_')[0].italics() + " " + speciesData.originalNameCombination.split('_')[1].italics();
+  }
+  originalName.innerHTML = "<b>Original name as described:</b> " + firstName;
+  
+  var specTax = document.createElement("p");
+  specTax.innerHTML = "<br><b>Taxonomy</b><br><br> <b>Major Type:</b> " + speciesData.majorType + " <b>-- " + "Major subtype:</b> " + speciesData.majorSubtype + "<b> -- " + 
+   "Order:</b> " + speciesData.order.charAt(0) + speciesData.order.slice(1).toLowerCase() 
+  + "<b> -- " + "Family: </b>" + speciesData.family.charAt(0) + speciesData.family.slice(1).toLowerCase() +
+  "<b> -- " + "Subfamily:</b> " + speciesData.subfamily.charAt(0) + speciesData.subfamily.slice(1).toLowerCase() +
+  "<b> -- " + "Tribe: </b>" + speciesData.tribe.charAt(0) + speciesData.tribe.slice(1).toLowerCase() + "<br><br>";
+  
+  var nominalNames = document.createElement("p");
+  nominalNames.innerHTML = "<b>Nominal names:</b> " + speciesData.nominalNames;
 
-      var originalName = document.createElement("p");
-      var firstName = "";
-      if (speciesData.originalNameCombination == "") {
-          firstName = "Name is as originally described.";
-      } else {
-          firstName = speciesData.originalNameCombination.split('_')[0].italics() + " " + speciesData.originalNameCombination.split('_')[1].italics();
-      }
-      originalName.innerHTML = "<b>Original name as described:</b> " + firstName;
-      
-      var specTax = document.createElement("p");
-      specTax.innerHTML = "<br><b>Taxonomy</b><br><br> <b>Major Type:</b> " + speciesData.majorType + " <b>-- " + "Major subtype:</b> " + speciesData.majorSubtype + "<b> -- " + 
-       "Order:</b> " + speciesData.order.charAt(0) + speciesData.order.slice(1).toLowerCase() 
-      + "<b> -- " + "Family: </b>" + speciesData.family.charAt(0) + speciesData.family.slice(1).toLowerCase() +
-      "<b> -- " + "Subfamily:</b> " + speciesData.subfamily.charAt(0) + speciesData.subfamily.slice(1).toLowerCase() +
-      "<b> -- " + "Tribe: </b>" + speciesData.tribe.charAt(0) + speciesData.tribe.slice(1).toLowerCase() + "<br><br>";
-      
-      var nominalNames = document.createElement("p");
-      nominalNames.innerHTML = "<b>Nominal names:</b> " + speciesData.nominalNames;
+  var specNotes = document.createElement("p")
+  specNotes.innerHTML = "<br>" + "<b>Species-specific notes: </b>" + speciesData.taxonomyNotes +
+  "<br><b> Citation:</b> " + speciesData.taxonomyNotesCitation + "<br>";
+  
+  var speciesStatus = document.createElement("p");
+  var extinct = "";
+  if (speciesData.extinct == "0") {
+      extinct = "This species is currently living,"
+  } else {
+      extinct = "This species went extinct in the last 500 years,"
+  }
+  var domestic = "";
+  if (speciesData.domestic == 0 && speciesData.extinct == 0) {
+      domestic = " it lives in wild habitats, "
+  } else if (speciesData.domestic == 0 && speciesData.extinct == 1) {
+      domestic = " it lived in wild habitats, ";
+  } else if (speciesData.domestic == 1 && speciesData.extinct == 0) {
+      domestic = " it lives in domestic habitats, "
+  } else {
+      domestic == " it lived in domestic habitats, "
+  }
+  var flagged = "";
+  if (speciesData.flagged == 0) {
+      flagged = "its taxonomic status is currently accepted, "
+  } else {
+      flagged = "its taxonomic status is currently flagged, "
+  }
+  var newSpp = "";
+  if (speciesData.diffSinceMSW3 == 0) {
+      newSpp = "and it is listed in MSW3 2005."
+  } else {
+      newSpp = "and it is newly recognized since MSW3 2005."
+  }
+  speciesStatus.innerHTML ="<b>Species Status:</b> " + extinct + domestic + flagged + newSpp;
+  
+  var iucnStatus = document.createElement("p");
+  var currentIucnStatus = "";
+  if (speciesData.iucnStatus == "NA") {
+      currentIucnStatus = "Not evaluated";
+  } else if (speciesData.iucnStatus == "DD") {
+      currentIucnStatus == "Data deficient";
+  } else if (speciesData.iucnStatus == "LC") {
+      currentIucnStatus = "Least concern";
+  } else if (speciesData.iucnStatus == "NT") {
+      currentIucnStatus = "Near threatened";
+  } else if (speciesData.iucnStatus == "VU") {
+      currentIucnStatus = "Vulnerable";
+  } else if (speciesData.iucnStatus == "EN") {
+      currentIucnStatus = "Endangered";
+  } else if (speciesData.iucnStatus == "CR") {
+      currentIucnStatus = "Critically endangered";
+  } else if (speciesData.iucnStatus == "EW") {
+      currentIucnStatus = "Extinct in the wild";
+  } else if (speciesData.iucnStatus == "EX") {
+      currentIucnStatus = "Extinct";
+  }
+  iucnStatus.innerHTML = "<b>IUCN Red List of Threatened Species status:</b> " + currentIucnStatus;
 
-      var specNotes = document.createElement("p")
-      specNotes.innerHTML = "<br>" + "<b>Species-specific notes: </b>" + speciesData.taxonomyNotes +
-      "<br><b> Citation:</b> " + speciesData.taxonomyNotesCitation + "<br>";
-      
-      var speciesStatus = document.createElement("p");
-      var extinct = "";
-      if (speciesData.extinct == "0") {
-          extinct = "This species is currently living,"
-      } else {
-          extinct = "This species went extinct in the last 500 years,"
-      }
-      var domestic = "";
-      if (speciesData.domestic == 0 && speciesData.extinct == 0) {
-          domestic = " it lives in wild habitats, "
-      } else if (speciesData.domestic == 0 && speciesData.extinct == 1) {
-          domestic = " it lived in wild habitats, ";
-      } else if (speciesData.domestic == 1 && speciesData.extinct == 0) {
-          domestic = " it lives in domestic habitats, "
-      } else {
-          domestic == " it lived in domestic habitats, "
-      }
-      var flagged = "";
-      if (speciesData.flagged == 0) {
-          flagged = "its taxonomic status is currently accepted, "
-      } else {
-          flagged = "its taxonomic status is currently flagged, "
-      }
-      var newSpp = "";
-      if (speciesData.diffSinceMSW3 == 0) {
-          newSpp = "and it is listed in MSW3 2005."
-      } else {
-          newSpp = "and it is newly recognized since MSW3 2005."
-      }
-      speciesStatus.innerHTML ="<b>Species Status:</b> " + extinct + domestic + flagged + newSpp;
-      
-      var iucnStatus = document.createElement("p");
-      var currentIucnStatus = "";
-      if (speciesData.iucnStatus == "NA") {
-          currentIucnStatus = "Not evaluated";
-      } else if (speciesData.iucnStatus == "DD") {
-          currentIucnStatus == "Data deficient";
-      } else if (speciesData.iucnStatus == "LC") {
-          currentIucnStatus = "Least concern";
-      } else if (speciesData.iucnStatus == "NT") {
-          currentIucnStatus = "Near threatened";
-      } else if (speciesData.iucnStatus == "VU") {
-          currentIucnStatus = "Vulnerable";
-      } else if (speciesData.iucnStatus == "EN") {
-          currentIucnStatus = "Endangered";
-      } else if (speciesData.iucnStatus == "CR") {
-          currentIucnStatus = "Critically endangered";
-      } else if (speciesData.iucnStatus == "EW") {
-          currentIucnStatus = "Extinct in the wild";
-      } else if (speciesData.iucnStatus == "EX") {
-          currentIucnStatus = "Extinct";
-      }
-      iucnStatus.innerHTML = "<b>IUCN Red List of Threatened Species status:</b> " + currentIucnStatus;
-
-      var breakChar = document.createElement("br");
-      
-      // var distribution = document.createElement("p");
-      // if (speciesData.extinct == 0) { 
-      //     distribution.innerHTML = "<b>Biogeographic realm:</b> " + speciesData.biogeographicRealm;
-      // } else {
-      //     distribution.innerHTML = "<b>Past biogeographic realm:</b> " + speciesData.biogeographicRealm;
-      // }
-      var distribution = document.createElement("p");
-      var countries = speciesData.countryDistribution
+  var breakChar = document.createElement("br");
+  
+  // var distribution = document.createElement("p");
+  // if (speciesData.extinct == 0) { 
+  //     distribution.innerHTML = "<b>Biogeographic realm:</b> " + speciesData.biogeographicRealm;
+  // } else {
+  //     distribution.innerHTML = "<b>Past biogeographic realm:</b> " + speciesData.biogeographicRealm;
+  // }
+  var distribution = document.createElement("p");
+  var countries = speciesData.countryDistribution
 .split("|")
 .map(function(countryName) { return addCodeForCountryName(countryName); });
-      var prefix = speciesData.extinct == 0 ? "" : "Past geographic";
-      distribution.innerHTML = "<b>" + prefix + " Country distribution</b> (coarse map shown below; most species exist in only part of countries): " + countries.map(formatCountryAndCode).join(" | ") + "<br><br>";
-      var distributionMap = document.createElement("div");
-      let mapId = "distributionMap";
-      distributionMap.setAttribute("id", mapId);
-      
-      var typelocality = document.createElement("p");
-      typelocality.innerHTML = "<b>Type locality:</b> " + speciesData.typeLocality + "<br>";
+  var prefix = speciesData.extinct == 0 ? "" : "Past geographic";
+  distribution.innerHTML = "<b>" + prefix + " Country distribution</b> (coarse map shown below; most species exist in only part of countries): " + countries.map(formatCountryAndCode).join(" | ") + "<br><br>";
+  var distributionMap = document.createElement("div");
+  let mapId = "distributionMap";
+  distributionMap.setAttribute("id", mapId);
+  
+  var typelocality = document.createElement("p");
+  typelocality.innerHTML = "<b>Type locality:</b> " + speciesData.typeLocality + "<br>";
 
-      var voucher = document.createElement("p");
-      voucher.innerHTML = "<b>Holotype voucher catalogue number:</b> " + speciesData.holotypeVoucher;
-      var contact = document.createElement("p");
-      contact.innerHTML = "<i>Please send any edits, corrections, or unfilled data (including full citations) to mammaldiversity [at] gmail [dot] com.</i>"
-      
-      resultsDisplay.appendChild(specHead);
-      resultsDisplay.appendChild(commonName);
-      resultsDisplay.appendChild(speciesCitation);
-      resultsDisplay.appendChild(authorityLink);
-      resultsDisplay.appendChild(originalName);
-      resultsDisplay.appendChild(nominalNames);
-      resultsDisplay.appendChild(otherCommonNames);
-      resultsDisplay.appendChild(specTax);
-      //resultsDisplay.appendChild(specAuthority);
-      resultsDisplay.appendChild(voucher);
-      resultsDisplay.appendChild(typelocality);
-      resultsDisplay.appendChild(distribution);
-      resultsDisplay.appendChild(distributionMap);
-      resultsDisplay.appendChild(speciesStatus);
-      resultsDisplay.appendChild(iucnStatus);
-      resultsDisplay.appendChild(specNotes);
-      resultsDisplay.appendChild(breakChar);
-      resultsDisplay.appendChild(specPermalink);
-      resultsDisplay.appendChild(contact);
-      document.body.insertBefore(resultsDisplay, mddTable);
-      drawCountriesOnMap(countries.filter( function(country) { return country.code !== undefined; }).map( function(country) { return country.code; }), mapId);
+  var voucher = document.createElement("p");
+  voucher.innerHTML = "<b>Holotype voucher catalogue number:</b> " + speciesData.holotypeVoucher;
+  var contact = document.createElement("p");
+  contact.innerHTML = "<i>Please send any edits, corrections, or unfilled data (including full citations) to mammaldiversity [at] gmail [dot] com.</i>"
+  
+  resultsDisplay.appendChild(specHead);
+  resultsDisplay.appendChild(commonName);
+  resultsDisplay.appendChild(speciesCitation);
+  resultsDisplay.appendChild(authorityLink);
+  resultsDisplay.appendChild(originalName);
+  resultsDisplay.appendChild(nominalNames);
+  resultsDisplay.appendChild(otherCommonNames);
+  resultsDisplay.appendChild(specTax);
+  //resultsDisplay.appendChild(specAuthority);
+  resultsDisplay.appendChild(voucher);
+  resultsDisplay.appendChild(typelocality);
+  resultsDisplay.appendChild(distribution);
+  resultsDisplay.appendChild(distributionMap);
+  resultsDisplay.appendChild(speciesStatus);
+  resultsDisplay.appendChild(iucnStatus);
+  resultsDisplay.appendChild(specNotes);
+  resultsDisplay.appendChild(breakChar);
+  resultsDisplay.appendChild(specPermalink);
+  resultsDisplay.appendChild(contact);
+  document.body.insertBefore(resultsDisplay, mddTable);
+  drawCountriesOnMap(countries.filter( function(country) { return country.code !== undefined; }).map( function(country) { return country.code; }), mapId);
+
+}
+
+function populateSpeciesInfo(results, speciesID) {
+  var speciesDataHits = results.data.filter(function(species) { return speciesID === species.id; }); 
+  speciesDataHits.forEach(function(speciesData) {
+    let permalink = permalinkFor(document.location.href, speciesData);
+    document.location = permalink;
+    renderSpeciesPage(speciesData, permalink);
+  });
 }
 
 function goPermalink(event) {

--- a/js/filter.js
+++ b/js/filter.js
@@ -200,18 +200,14 @@ function populateSpeciesInfo(results, speciesID) {
   var speciesDataHits = results.data.filter(function(species) { return speciesID === species.id; }); 
   speciesDataHits.forEach(function(speciesData) {
     let permalink = permalinkFor(document.location.href, speciesData);
-    document.location = permalink;
+    document.location.replace(permalink);
     renderSpeciesPage(speciesData, permalink);
   });
 }
 
 function goPermalink(event) {
-    if (document.location.hash != "") {
-        speciesID = document.location.hash.split("=")[3];
-        var element = document.createElement("input");
-        element.value = speciesID;
-        fillSpeciesInfo(element);
-    }
+    let speciesId = speciesIdForPermalink(document.location.href);
+    speciesId || loadSpeciesById(speciesId);
 }
 
 
@@ -587,11 +583,14 @@ function loadMDD(onLoad) {
   onLoad({ data: mdd });
 }
 
-function fillSpeciesInfo(elem) {
-    var speciesID = elem.value;
+function loadSpeciesById(speciesID) {
     loadMDD(function(results) {
       populateSpeciesInfo(results, speciesID);
     });
+}
+
+function fillSpeciesInfo(elem) {
+    loadSpeciesById(elem.value);
 }
 
 

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -2,9 +2,9 @@
 function permalinkFor(urlString, speciesData) {
    //The current URL may or may not have a "#" at the end already. Handle both cases.
    var baseUrl = urlString === null ? '' : urlString.split("#")[0];
-   let hasSpeciesData = speciesData !== undefined && speciesData.id && speciesData.genus && speciesData.specificEpithet;
+   let hasSpeciesData = speciesData !== undefined && speciesData.id;
    var permalink = hasSpeciesData 
-        ? baseUrl + "#genus=" + speciesData.genus + "&" + "species=" + speciesData.specificEpithet + "&" + "id=" + speciesData.id
+        ? baseUrl + "#id=" + speciesData.id
         : baseUrl;
    return permalink;
 }

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -9,6 +9,14 @@ function permalinkFor(urlString, speciesData) {
    return permalink;
 }
 
+function speciesIdFor(urlString) {
+  let matches = urlString.match(/id=(?<id>[0-9]+)/);
+  return matches ? matches.groups.id : undefined;
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = permalinkFor;
+  module.exports = { 
+     permalinkFor: permalinkFor,
+     speciesIdFor: speciesIdFor
+  };
 }

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -1,5 +1,5 @@
 
-function permalink(urlString, speciesData) {
+function permalinkFor(urlString, speciesData) {
    //The current URL may or may not have a "#" at the end already. Handle both cases.
    var baseUrl = urlString === null ? '' : urlString.split("#")[0];
    let hasSpeciesData = speciesData !== undefined && speciesData.id && speciesData.genus && speciesData.specificEpithet;
@@ -10,5 +10,5 @@ function permalink(urlString, speciesData) {
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = permalink;
+  module.exports = permalinkFor;
 }

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -4,13 +4,13 @@ function permalinkFor(urlString, speciesData) {
    var baseUrl = urlString === null ? '' : urlString.split("#")[0];
    let hasSpeciesData = speciesData !== undefined && speciesData.id;
    var permalink = hasSpeciesData 
-        ? baseUrl + "#id=" + speciesData.id
+        ? baseUrl + "#" + speciesData.id
         : baseUrl;
    return permalink;
 }
 
 function speciesIdFor(urlString) {
-  let matches = urlString.match(/id=(?<id>[0-9]+)/);
+  let matches = urlString.match(/((#)|(id=))(?<id>[0-9]+)/);
   return matches ? matches.groups.id : undefined;
 }
 

--- a/test/permalink.js
+++ b/test/permalink.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var permalinkFor = require('../js/permalink.js');
+var p = require('../js/permalink.js');
 
 // see https://www.npmjs.com/package/tape for example on how to write unit tests
 
@@ -11,25 +11,38 @@ test('sample test', function (t) {
 
 test('permalink no hash', function (t) {
     t.plan(1);
-    var actual = permalinkFor('https://example.org/', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
+    var actual = p.permalinkFor('https://example.org/', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
     t.equal(actual, "https://example.org/#genus=Donald&species=duckus&id=1234"); 
 });
 
 test('permalink with existing hash', function (t) {
     t.plan(1);
-    var actual = permalinkFor('https://example.org/#foo', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
+    var actual = p.permalinkFor('https://example.org/#foo', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
     t.equal(actual, "https://example.org/#genus=Donald&species=duckus&id=1234"); 
 });
 
 test('permalink null string', function (t) {
     t.plan(1);
-    var actual = permalinkFor(null, { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
+    var actual = p.permalinkFor(null, { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
     t.equal(actual, "#genus=Donald&species=duckus&id=1234"); 
 });
 
 
 test('permalink empty speciesData', function (t) {
     t.plan(1);
-    var actual = permalinkFor('https://example.org', {} ); 
+    var actual = p.permalinkFor('https://example.org', {} ); 
     t.equal(actual, "https://example.org"); 
+});
+
+
+test('species id for permalink', function (t) {
+    t.plan(1);
+    var actual = p.speciesIdFor('https://example.org#id=11234', {} ); 
+    t.equal(actual, "11234"); 
+});
+
+test('no species id', function (t) {
+    t.plan(1);
+    var actual = p.speciesIdFor('https://example.org#id=invalid1234', {} ); 
+    t.equal(actual, undefined); 
 });

--- a/test/permalink.js
+++ b/test/permalink.js
@@ -47,6 +47,12 @@ test('ignore invalid', function (t) {
     t.equal(actual, undefined); 
 });
 
+test('backwards compatibility test', function (t) {
+    t.plan(1);
+    var actual = p.speciesIdFor('https://www.mammaldiversity.org/explore.html#genus=Zaglossus&species=attenboroughi&id=1000003', {} ); 
+    t.equal(actual, '1000003'); 
+});
+
 test('ignore port number', function (t) {
     t.plan(1);
     var actual = p.speciesIdFor('https://example.org:4000', {} ); 

--- a/test/permalink.js
+++ b/test/permalink.js
@@ -12,19 +12,19 @@ test('sample test', function (t) {
 test('permalink no hash', function (t) {
     t.plan(1);
     var actual = p.permalinkFor('https://example.org/', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
-    t.equal(actual, "https://example.org/#genus=Donald&species=duckus&id=1234"); 
+    t.equal(actual, "https://example.org/#id=1234"); 
 });
 
 test('permalink with existing hash', function (t) {
     t.plan(1);
     var actual = p.permalinkFor('https://example.org/#foo', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
-    t.equal(actual, "https://example.org/#genus=Donald&species=duckus&id=1234"); 
+    t.equal(actual, "https://example.org/#id=1234"); 
 });
 
 test('permalink null string', function (t) {
     t.plan(1);
     var actual = p.permalinkFor(null, { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
-    t.equal(actual, "#genus=Donald&species=duckus&id=1234"); 
+    t.equal(actual, "#id=1234"); 
 });
 
 

--- a/test/permalink.js
+++ b/test/permalink.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var permalink = require('../js/permalink.js');
+var permalinkFor = require('../js/permalink.js');
 
 // see https://www.npmjs.com/package/tape for example on how to write unit tests
 
@@ -11,25 +11,25 @@ test('sample test', function (t) {
 
 test('permalink no hash', function (t) {
     t.plan(1);
-    var actual = permalink('https://example.org/', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
+    var actual = permalinkFor('https://example.org/', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
     t.equal(actual, "https://example.org/#genus=Donald&species=duckus&id=1234"); 
 });
 
 test('permalink with existing hash', function (t) {
     t.plan(1);
-    var actual = permalink('https://example.org/#foo', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
+    var actual = permalinkFor('https://example.org/#foo', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
     t.equal(actual, "https://example.org/#genus=Donald&species=duckus&id=1234"); 
 });
 
 test('permalink null string', function (t) {
     t.plan(1);
-    var actual = permalink(null, { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
+    var actual = permalinkFor(null, { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
     t.equal(actual, "#genus=Donald&species=duckus&id=1234"); 
 });
 
 
 test('permalink empty speciesData', function (t) {
     t.plan(1);
-    var actual = permalink('https://example.org', {} ); 
+    var actual = permalinkFor('https://example.org', {} ); 
     t.equal(actual, "https://example.org"); 
 });

--- a/test/permalink.js
+++ b/test/permalink.js
@@ -12,19 +12,19 @@ test('sample test', function (t) {
 test('permalink no hash', function (t) {
     t.plan(1);
     var actual = p.permalinkFor('https://example.org/', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
-    t.equal(actual, "https://example.org/#id=1234"); 
+    t.equal(actual, "https://example.org/#1234"); 
 });
 
 test('permalink with existing hash', function (t) {
     t.plan(1);
     var actual = p.permalinkFor('https://example.org/#foo', { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
-    t.equal(actual, "https://example.org/#id=1234"); 
+    t.equal(actual, "https://example.org/#1234"); 
 });
 
 test('permalink null string', function (t) {
     t.plan(1);
     var actual = p.permalinkFor(null, { id: 1234, genus: "Donald", specificEpithet: "duckus"} ); 
-    t.equal(actual, "#id=1234"); 
+    t.equal(actual, "#1234"); 
 });
 
 
@@ -41,8 +41,21 @@ test('species id for permalink', function (t) {
     t.equal(actual, "11234"); 
 });
 
-test('no species id', function (t) {
+test('ignore invalid', function (t) {
     t.plan(1);
     var actual = p.speciesIdFor('https://example.org#id=invalid1234', {} ); 
     t.equal(actual, undefined); 
 });
+
+test('ignore port number', function (t) {
+    t.plan(1);
+    var actual = p.speciesIdFor('https://example.org:4000', {} ); 
+    t.equal(actual, undefined); 
+});
+
+test('bare species id', function (t) {
+    t.plan(1);
+    var actual = p.speciesIdFor('https://example.org#1234', {} );
+    t.equal(actual, '1234');
+});
+


### PR DESCRIPTION
Hey @JelleZijlstra @n8upham - 

For your review, I've created changes to work towards a more simplified permalink for MDD - 

Previously, genus, specificEpithet and identifier was included - 

e.g., 

https://www.mammaldiversity.org/explore.html#genus=Zaglossus&species=attenboroughi&id=1000003

Now, 

https://www.mammaldiversity.org/explore.html#1000003

is supported. 

Eventually, as discussed in #24 , we'd like to move towards something like:

https://mammaldiversity.org/taxon/1000003 , or perhaps even https://mammaldiversity.org/1000003 . 

instead. 

With the changes included here:

1. https://www.mammaldiversity.org/explore.html#genus=Zaglossus&species=attenboroughi&id=1000003 redirects to https://www.mammaldiversity.org/explore.html#1000003

2. https://www.mammaldiversity.org/explore.html#id=1000003 redirects to https://www.mammaldiversity.org/explore.html#1000003

and

3. https://www.mammaldiversity.org/explore.html#1000003 is listed as the permalink on the species status panels.

Please review and feel free to ask questions or accept to have the change propagate.

Thanks!