### PR TITLE
simplify navigation from search/explore to taxon page so that back/fo…

### DIFF
--- a/explore.md
+++ b/explore.md
@@ -21,7 +21,7 @@ title: Explore the Database
     <tbody>
         {% for species in site.data.mdd %}
             <tr>
-            <td><a href="#{{ species.id }}"><input type = "button" class="text-button" onclick = "fillSpeciesInfo(this)" id = "speciesID" value = "{{ species.id }}"></a></td>
+            <td><a href="taxon/{{ species.id }}">{{ species.id }}</a></td>
             <td><i>{{ species.genus }}</i></td>
             <td><i>{{ species.specificEpithet }}</i></td>
             <td>{{ species.family | downcase | capitalize }}</td>

--- a/js/filter.js
+++ b/js/filter.js
@@ -208,8 +208,8 @@ function populateSpeciesInfo(results, speciesID) {
 
 function goPermalink(event) {
     let speciesId = speciesIdFor(document.location.href);
-    if (speciesId !== undefined) {
-      loadSpeciesById(speciesId);
+    if (speciesId !== undefined && speciesId.match(/[0-9]+/)) {
+       document.location = permalinkForTaxonId(speciesId);
     }
 }
 

--- a/js/map.js
+++ b/js/map.js
@@ -11,7 +11,7 @@ function drawCountriesOnMap(countryCodes, elementId) {
   let distribution = new L.FeatureGroup();
   countryCodes.forEach(function(countryCode) {
       async function addGeoJson() {
-      const response = await fetch("assets/countries/" + countryCode + ".json");
+      const response = await fetch("/assets/countries/" + countryCode + ".json");
       const shape = await response.json();
       if (shape) {
         distribution.addLayer(L.geoJSON(shape));

--- a/js/permalink.js
+++ b/js/permalink.js
@@ -14,6 +14,10 @@ function permalinkFor(urlString, speciesData) {
    return permalinkForTaxonPage(permalink, speciesData);
 }
 
+function permalinkForTaxonId(taxonId) {
+  return "/taxon/" + taxonId;
+}
+
 function speciesIdForTaxonPage(urlString) {
   let matches = urlString.match(/\/taxon\/(?<id>[0-9]+)/);
   return matches ? matches.groups.id : undefined;


### PR DESCRIPTION
…rward buttons can be used; for your review @n8upham @JelleZijlstra

Related to https://github.com/mammaldiversity/mammaldiversity.github.io/issues/24 .

The idea to work towards "aspirationally" stable taxon identifiers.  

With this pull request - you'd be redirect to a .../taxon/1235 page from the "explore" pages instead of having some result pop up inside the search result page.

Curious to hear your thoughts,
-jorrit