### PR TITLE
Add GH action release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  # Create release from data MDD.zip
+  release:
+    runs-on: ubuntu-latest
+    env:
+      DATA_PATH: assets/data
+      MDD_FILENAME: MDD.zip
+      SHA256_FILENAME: MDD_zip_sha256.txt
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Create hash
+      # But exclude the hash file path being written to the hash file
+      - name: Create hash
+        run: |
+          echo "Creating hash"
+          sha256sum $DATA_PATH/$MDD_FILENAME | awk '{print $1}' > $DATA_PATH/$SHA256_FILENAME
+
+      - name: Upload release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{env.DATA_PATH}}/${{env.MDD_FILENAME}}
+          asset_name: ${{env.MDD_FILENAME}}
+          tag: ${{ github.ref }}
+
+      - name: Upload hash
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{env.DATA_PATH}}/${{env.SHA256_FILENAME}}
+          asset_name: ${{env.SHA256_FILENAME}}
+          tag: ${{ github.ref }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,334 @@
+abstract: '<p>Accurate taxonomy is central to the study of biological diversity, as
+  it provides the needed evolutionary framework for taxon sampling and interpreting
+  results. While the number of recognized species in the class Mammalia has increased
+  through time, tabulation of those increases has relied on the sporadic release of
+  revisionary compendia like the <em>Mammal Species of the World</em> (MSW) series.
+  Here, we present the <strong>Mammal Diversity Database</strong> (MDD), a digital,
+  publically accessible, and updateable list of all mammalian species, now available
+  online: <a href="https://mammaldiversity.org">https://mammaldiversity.org</a>. The
+  MDD will continue to be updated as manuscripts describing new species and higher
+  taxonomic changes are released. Starting from the baseline of the 3rd edition of
+  MSW (MSW3), we performed a review of taxonomic changes published since 2004 and
+  digitally linked species names to their original descriptions and subsequent revisionary
+  articles in an interactive, hierarchical database. The MDD provides the mammalogical
+  community with an updateable online database of taxonomic changes, joining digital
+  efforts already established for amphibians (AmphibiaWeb, AMNH&rsquo;s Amphibian
+  Species of the World), birds (e.g., Avibase, IOC World Bird List, HBW Alive), non-avian
+  reptiles (The Reptile Database), and fish (e.g., FishBase, Catalog of Fishes).</p>
+
+  <p>Development for this work is funded primarily by the <a href="http://www.mammalsociety.org/">American
+  Society of Mammalogists</a> (ASM; 2017-present), with initial logistical and planning
+  support (2017-2019) provided by the <a href="http://vertlife.org/grant/">NSF Vertlife
+  Terrestrial grant</a>. Logistical support is now also being provided by the <a href="https://biokic.asu.edu/">Biodiversity
+  Knowledge Integration Center</a> at Arizona State University.</p>
+
+  <p>The <a href="http://www.mammalsociety.org/committees/biodiversity">ASM Biodiversity
+  Committee</a> compiles and maintains the MDD, curating regular releases that are
+  downloadable in comma-delimited format. Downstream goals include expanded hosting
+  of ecological, trait, and taxonomic data. Overall, this initiative aims to promote
+  the ASM&rsquo;s role as a leader in high quality research on mammalian biology.</p>
+
+  <p>A new section on <strong>Subjective Decisions</strong> has been added to the
+  <a href="https://www.mammaldiversity.org/about.html">MDD About page</a> for use
+  in summarizing opinion-based decisions of the MDD team that depart from the most
+  recently published peer-reviewed article on a given taxon. Some of these decisions
+  are made in collaboratoration with the Global Bat Taxonomy Working Group of the
+  <a href="https://www.iucnbsg.org/">IUCN SSC Bat Specialist Group</a> to promote
+  harmonization between the MDD and batnames.org. Future subjective decisions will
+  also be authored by the MDD Taxonomic Subcommittees that we are assembling in early
+  2024.</p>
+
+  <p><strong>Version 1.12.1</strong> (30 January 2024). This is minor release that
+  fixes a spelling error in a new species to <em>Euryoryzomys cerqueirai </em>(from
+  <em>E. cerqueriai</em>). This version is also the first to display country-based
+  maps on the per species pages as populated from the ''countryDistribution'' field
+  (e.g., see: https://www.mammaldiversity.org/explore.html#genus=Peromyscus&amp;species=maniculatus&amp;id=1002307).
+  Thanks to Jorrit Poelen for some stellar work here!</p>
+
+  <p><strong>Version 1.12</strong> (5 January 2024). This is an incremental release
+  that documents 6,718 total species, of which 107 are recently extinct (addition
+  of 2 species since v1.11) and 6,611 are extant (17 domestic extant, 6,594 wild extant).
+  There are now 27 species flagged for further review. The <strong>holotypeVoucher</strong>
+  field is filled for 2,727 accepted species thanks to the efforts of the MDD team
+  (35 NA''s indicate a real lack of actual voucher--in need of neotype). The&nbsp;<strong>Tracked
+  Differences</strong> file ("Diff_v1.11-v1.12.csv") documents taxonomic changes made
+  since the last MDD version, which include 115 changes during the last 8 months (compares
+  to 194 changes from v1.10-v1.11 and 117 changes from v1.9 to v1.10, and ~30 changes
+  between versions before that). Differences include 77 new species recognized (38
+  de novo, 38 split, 1 revalidation), 8 synonymizations (lumps), 31 species with genus
+  name changes, 7 genus additions (<em>Bisbalus, Passalites, Subulo, Neoeptesicus,
+  Mictomys, Cnephaeus, Cordimus</em>) and 1 genus lump <em>(Nesoromys</em>), and 1
+  removed domestic species (<em>Homo sapiens</em>, given a revised MDD definition
+  of domestication to be ''domesticated by human artificial selection''; see About
+  page). In total, there was a net increase of 69 species and net increase of 6 genera
+  of recognized extant or recently extinct mammals since MDD v1.11.</p>
+
+  <p><strong>Version 1.11</strong> (15 April 2023). This is an incremental release
+  that documents 6,649 total species, of which 105 are recently extinct (addition
+  of 4 species since v1.10) and 6,544 are extant (18 domestic extant, 6,526 wild extant).
+  There are now only 21 species flagged for further review. The <strong>holotypeVoucher</strong>
+  field is filled for 2,731 accepted species thanks to the efforts of the MDD team
+  (NA''s indicate a real lack of actual voucher--in need of neotype). The <strong>Tracked
+  Differences</strong> file ("Diff_v1.10-v1.11.csv") documents taxonomic changes made
+  since the last MDD version, which have been extensive recently due to enhanced activity,
+  leading to a whopping 194 changes during the last 4 months (compares to 117 changes
+  in the last version, and ~30 changes between previous versions). Differences include
+  64 new species recognized (15 de novo, 49 split), 29 synonymizations (lumps, including
+  2 domestic species<em>: Bos domesticus</em> into <em>Bos javanicus</em>, and <em>Bos
+  indicus</em> into <em>Bos taurus</em>), 1 species removal (<em>Makalata obscura</em>,
+  now considered nomen dubium), 36 species with genus name changes, 5 genus additions
+  (<em>Otohylomys, Baeodon, Neusticomys, Poecilictis, </em>and <em>Parachoerus</em>)
+  and 7 genus lumps (<em>Crossogale, Aeorestes, Dasypterus, Koopmania, Pediolagus,
+  Petropseudes, Catagonus</em>), 5 species epithet changes to clear up confusion,
+  47 species epithet spelling changes to match gender or the original description
+  (this was a major emphasis of this version&ndash; to come into harmony with batnames.org
+  and hesperomys.com), and 1 error fix in the spelling of the common name "Australian
+  Humpback Dolphin". In total, there was a net increase of 34 species and net decrease
+  of 2 genera of recognized extant or recently extinct mammals since MDD v1.10.</p>
+
+  <p><strong>Version 1.10</strong> (3 Dec 2022). This is an incremental release that
+  documents 6,615 total species, of which 101 are recently extinct and 6,514 are extant
+  (20 domestic extant, 6,494 wild extant). There are now 33 species flagged for further
+  review (subtraction of <em>Dromiciops mondaca</em>, which was synonymized under
+  <em>D. gliroides</em>). The <strong>holotypeVoucher</strong> field is now filled
+  for 2,731 accepted species thanks to the continued efforts of Ingrid Rochon, Connor
+  Burgin, and also now Bruce Patterson (NA''s indicate a real lack of actual voucher--in
+  need of neotype). The <strong>Tracked Differences</strong> file ("Diff_v1.9-v1.10.csv")
+  documents taxonomic changes made since the last MDD version, which was 8 months
+  ago (1 April 2022) so 117 changes are included now versus the ~30 changes between
+  previous versions. Differences include 49 new species recognized (22 de novo, 27
+  split), 30 synonymizations (lumps), 29 species with genus name changes (affecting
+  <em>Lissonycteris -&gt; Myonycteris, Aonyx/Lutrogale -&gt; Lutra, Eothenomys -&gt;
+  Anteliomys, Ellobius -&gt; Bramus, Proedromys -&gt; Mictomicrotus, Lasiopodomys
+  </em>back to <em>Stenocranius, and Cephalophus -&gt; Cephalophorus</em>), 3 species
+  epithet changes to clear up confusion, 5 species epithet spelling changes to match
+  gender or the original description, and 1 error fix shifting <em>Capra hircus</em>
+  to domestic status as the domestic form of <em>C. aegagrus</em>. In total, there
+  was a net increase of 19 species and 5 genera of recognized extant or recently extinct
+  mammals since MDD v1.9.</p>
+
+  <p><strong>Version 1.9.1</strong> (29 Jun 2022). This is a patch release that adds
+  the field ''<strong>holotypeVoucherURIs</strong>'' to the MDD taxonomy file for
+  use in linking the type specimens to external website(s), including the hosting
+  museum collection. Currently this feature is experimental. The taxonomy still includes
+  6,596 total species, of which 101 are recently extinct &amp; 6,495 are extant (19
+  domestic extant, 6,476 wild extant).</p>
+
+  <p><strong>Version 1.9</strong> (1 Apr 2022). This is an incremental release that
+  documents 6,596 total species, of which 101 are recently extinct and 6,495 are extant
+  (19 domestic extant, 6,476 wild extant). There are now 34 species flagged for further
+  review (addition of 6 species related to the split of <em>Lagenorhynchus</em> dolphins,
+  along with the previous inclusion of some Cebus species). The <strong>holotypeVoucher</strong>
+  field is now filled for 2,662 accepted species thanks to the continued efforts of
+  Ingrid Rochon and Connor Burgin (NA''s indicate a real lack of actual voucher--in
+  need of neotype). The <strong>Tracked Differences</strong> file ("Diff_v1.8-v1.9.csv")
+  documents taxonomic changes made since the last MDD version, and here includes 15
+  new species recognized (8 de novo, 7 split), 10 synonymizations (lumps), 2 species
+  with genus name changes (<em>Brachylagus idahoensis</em> to <em>Sylvilagus idahoensis
+  </em>and <em>Nycticebus pygmaeus</em> to <em>Xanthonycticebus pygmaeus</em>), and
+  1 range extension (for <em>Marmosa alstoni</em> extended to Panama; https://doi.org/10.5281/zenodo.6374907).
+  In total, there was a net increase of 5 recognized species of extant or recently
+  extinct mammals since MDD v1.8.</p>
+
+  <p><strong>Version 1.8</strong> (1 Feb 2022). This is an incremental release that
+  documents 6,591 total species, of which 101 are recently extinct and 6,490 are extant
+  (19 domestic extant, 6,471 wild extant). There are still 28 species flagged for
+  further review (e.g., some Cebus species). The <strong>holotypeVoucher</strong>
+  field is now filled for 2,665 accepted species thanks to the continued efforts of
+  Ingrid Rochon and Connor Burgin (NA''s indicate a real lack of actual voucher--in
+  need of neotype). The <strong>Tracked Differences</strong> file ("Diff_v1.7-v1.8.csv")
+  documents taxonomic changes made since the last MDD version, and here includes 27
+  new species recognized (21 de novo, 6 split), 3 synonymizations, 1 genus change
+  (Nasuella into Nasua, resulting in a reduction in the total number of genera), and
+  3 species name changes (2 based on new genetic evidence and naming priority, 1 on
+  a spelling change). In total, there was a net increase of 24 recognized species
+  of extant or recently extinct mammals since MDD v1.7.</p>
+
+  <p><strong>Version 1.7</strong> (6 Nov 2021). This is an incremental release that
+  documents 6,567 total species, of which 101 are recently extinct and 6,466 are extant
+  (19 domestic extant, 6,447 wild extant). There are now 28 species flagged for further
+  review (e.g., some Cebus species). The <strong>holotypeVoucher</strong> field is
+  now filled for 2,512 accepted species thanks to the continued efforts of Ingrid
+  Rochon and Connor Burgin (including a reduction of NA''s from 103 to 26). The <strong>Tracked
+  Differences</strong> file ("Diff_v1.6-v1.7.csv") documents taxonomic changes made
+  since the last MDD version, and here includes 19 new species recognized (13 de novo,
+  6 split), 9 synonymizations, 12 genus changes, and 2 de-extinctions due to taxonomic
+  changes (extinct <em>Gazella bilkis</em> synonymized under extant <em>Gazella arabica</em>
+  following B&auml;rmann et al. 2013<em>; </em>extinct <em>Pseudomys gouldii </em>changed
+  to extant since extant <em>Pseudomys fieldi</em> was synonymized under it in the
+  MDD v1.6 following Roycroft et al. 2021). In total, there was a net increase of
+  10 recognized species of extant or recently extinct mammals since MDD v1.6.</p>
+
+  <p><strong>Version 1.6</strong> (10 Aug 2021). This is an incremental release that
+  documents 6,557 total species, of which 103 are recently extinct and 6,454 are extant
+  (19 domestic extant, 6,435 wild extant). There are 29 species still flagged for
+  further review (e.g., some Cebus species). The <strong>holotypeVoucher</strong>
+  field is now filled for 2,548 accepted species thanks to the continued efforts of
+  Ingrid Rochon. The <strong>Tracked Differences</strong> file ("Diff_v1.5-v1.6.csv")
+  documents taxonomic changes made since the last MDD version, and here includes 9
+  new species recognized (5 de novo, 4 split), 5 synonymizations, 1 removal (<em>Dryomys
+  yarkandensis</em> invalid while in pre-print), and 18 genus changes.</p>
+
+  <p><strong>Version 1.5</strong> (11 Jun 2021). This is an incremental release that
+  documents 6,554 total species, of which 103 are recently extinct and 6,451 are extant
+  (19 domestic extant, 6,432 wild extant). There are 29 species still flagged for
+  further review (e.g., some Cebus species). The <strong>holotypeVoucher</strong>
+  field, which now filled for 2,459 accepted species thanks to the continued efforts
+  of Ingrid Rochon. We also continue to maintain the <strong>Tracked Differences</strong>
+  file ("Diff_v1.4-v1.5.csv") which documents which taxonomic changes were made per
+  species since the last MDD version. We still plan to retrospectively assemble these
+  diff files for previous versions as well.</p>
+
+  <p><strong>Version 1.4</strong> (11 Apr 2021). This is an incremental release that
+  documents 6,533 total species, of which 103 are recently extinct, 19 are domestic
+  extant, and 6,411 are wild extant. There are 29 species still flagged for further
+  review (e.g., some Cebus species). Especially improved in this version is the <strong>holotypeVoucher</strong>
+  field, which now filled for 2,153 accepted species thanks to the heroic efforts
+  of Ingrid Rochon (nearly 1/3 of mammals!!). Additionally, this time we added a <strong>Tracked
+  Differences</strong> file ("Diff_v1.31-v1.4.csv") which documents which taxonomic
+  changes were made per species since the last MDD version. We plan to retrospectively
+  assemble these diff files for previous versions as well. Note also that the per-species
+  notes (<strong>taxonomyNotes</strong>) are now updated through all mammals including
+  Chiroptera thanks to the careful efforts of David Huckaby and Connor Burgin. Those
+  notes should help clarify changes since MSW3, which is the well-recognized baseline
+  for mammal taxonomy from which the MDD is updating.</p>
+
+  <p><strong>Version 1.3.1</strong> (8 Jan 2021). This is an patch release that, like
+  v1.3, documents 6,513 total species, but also (i) fixes some bugs in the type locality
+  listings; and (ii) completes the improved documentation in the <strong>per-species
+  notes</strong> across all orders including Chiroptera (carefully curated by David
+  Huckaby and Connor Burgin; thanks both!). These completed notes clarify changes
+  since MSW3, which is the well-recognized baseline for mammal taxonomy from which
+  the MDD is updating.</p>
+
+  <p><strong>Version 1.3</strong> (28 Dec 2020). This is an incremental release that
+  documents 6,513 total species, of which 103 are recently extinct, 19 are domestic
+  extant, and 6,391 are wild extant. There are 29 species still flagged for further
+  review (e.g., some Cebus species). Especially improved in this version are the <strong>per-species
+  notes</strong>, which have been carefully curated by David Huckaby and Connor Burgin
+  for all mammal orders except Chiroptera (expect those updates in the next version).
+  These notes were written to help clarify changes since MSW3, which is the well-recognized
+  baseline for mammal taxonomy from which the MDD is updating.</p>
+
+  <p><strong>Version 1.2</strong> (24 Sep 2020). This is a major update, though still
+  incremental toward a more definitive forthcoming release. This release documents
+  6,485 total species, of which 103 are recently extinct, 19 are domestic extant,
+  and 6,363 are wild extant. Ten species are still "flagged" for further review. This
+  taxonomy and associated data (type locality, authorities, common names) are improved
+  by reference to the <em>Handbook of the Mammals of the World</em> series. Additionally,
+  justifications and citations are now provided for any subjective decisions made,
+  the most substantial of which has been the recommendations of Groves and Grubb (2011)&rsquo;s
+  compendium <em>Ungulate Taxonomy</em>. That taxonomy of Perissodactyla and non-cetacean
+  Artiodactyla was fully included in the v1.0 release of the MDD (Burgin et al. 2018).
+  However, since Groves and Grubb (2011) was based primarily on qualitative morphological
+  diagnoses with small sample sizes, it has since become controversial in the mammalogical
+  community (e.g., (Holbrook 2013; Guti&eacute;rrez and Garbino 2018)). Many specialists
+  have subsequently reverted to the taxonomic arrangement presented by Peter Grubb
+  in MSW3. In current versions of the MDD, we use MSW3 as a baseline for ungulate
+  taxonomy, leaving out all changes made by Groves and Grubb (2011) with the exception
+  of those supported by other published research. Note: this MDD v1.2 taxonomy is
+  also paired with <strong>species-level geographic range maps</strong> for 6,362
+  species, available at <a href="https://doi.org/10.5281/zenodo.6644198">https://doi.org/10.5281/zenodo.6644198</a>
+  as mirrored from the data publication of Marsh et al. 2022 (<a href="https://doi.org/10.1111/jbi.14330">https://doi.org/10.1111/jbi.14330</a>).
+  This range map data set differs from the 6,485 total species in MDD v1.2, as follows:</p>
+
+  <ul>
+
+  <li>excludes all recently extinct (103) and domestic species (20; correcting for
+  <em>Capra hircus</em> that was coded as ''domestic=0'' rather than ''domestic=1''
+  originally);</li>
+
+  <li>excludes 2 species for which no spatial information was available (<em>Nycticeius
+  aenobarbus</em> and <em>Phoniscus aerosus</em>); and</li>
+
+  <li>includes 2 species<em> </em>(<em>Elaphurus davidianus</em> and <em>Oryx dammah</em>)
+  that are extinct in the wild (EW) in IUCN, but which have recent range information
+  and were coded in the MDD as extant.</li>
+
+  </ul>
+
+  <p><strong>Version 1.1</strong> (29 Mar 2019). This is an incremental release that
+  documents 6,526 total species, of which 100 are recently extinct, 17 are domestic
+  extant, and 6,409 are wild extant.&nbsp; Of those, 212 species are "flagged" for
+  further review (mostly ungulates from Groves &amp; Grubb, 2011).</p>
+
+  <p><strong>Version 1.0</strong> (1 Feb 2018; described in <a href="https://doi.org/10.1093/jmammal/gyx147">https://doi.org/10.1093/jmammal/gyx147</a>).
+  We found 6,495 species of currently recognized mammals (96 recently extinct, 6,399
+  extant), compared to 5,416 in MSW3 (75 extinct, 5,341 extant)&mdash;an increase
+  of 1,079 species in about 13 years, including 11 species newly described as having
+  gone extinct in the last 500 years. We tabulate 1,251 new species recognitions,
+  at least 172 unions, and multiple major, higher-level changes, including an additional
+  88 genera (1,314 now, compared to 1,226 in MSW3) and 14 newly recognized families
+  (167 compared to 153). Analyses of the description of new species through time and
+  across biogeographic regions show a long-term global rate of ~25 species recognized
+  per year, with the Indomalayan biogeographic region as the overall most species-dense
+  for mammals globally (127.1 species/km<sup>2</sup>), followed by Australasia-Oceania
+  (90.6) and the Neotropics (85.1).</p>
+
+  <p>&nbsp;</p>
+
+  <p><strong>References</strong></p>
+
+  <p>&nbsp;</p>
+
+  <p>BURGIN, C. J., J. P. COLELLA, P. L. KAHN, AND N. S. UPHAM. 2018. How many species
+  of mammals are there? Journal of Mammalogy 99:1&ndash;14.</p>
+
+  <p>GROVES, C., AND P. GRUBB. 2011. Ungulate Taxonomy. JHU Press.</p>
+
+  <p>GUTI&Eacute;RREZ, E. E., AND G. S. T. GARBINO. 2018. Species delimitation based
+  on diagnosis and monophyly, and its importance for advancing mammalian taxonomy.
+  Zoological Research:97.</p>
+
+  <p>HOLBROOK, L. T. 2013. Taxonomy Interrupted. Journal of Mammalian Evolution 20:153&ndash;154.</p>
+
+  <p>WILSON, D. E., AND D. M. REEDER. 2005. Mammal species of the world: a taxonomic
+  and geographic reference, 3rd ed. 3rd edition. Johns Hopkins University Press, Baltimore,
+  MD.</p>'
+authors:
+- affiliation: American Society of Mammalogists
+  family-names: Mammal Diversity Database
+- affiliation: Arizona State University
+  family-names: Upham
+  given-names: Nathan
+  orcid: 0000-0001-5412-9342
+- family-names: Burgin
+  given-names: Connor
+  orcid: 0000-0001-6577-2739
+- family-names: Widness
+  given-names: Jane
+  orcid: 0000-0002-9284-2066
+- family-names: Liphardt
+  given-names: Schuyler
+- family-names: Parker
+  given-names: Camila
+- family-names: Becker
+  given-names: Madeleine
+  orcid: 0000-0003-2051-2911
+- family-names: Rochon
+  given-names: Ingrid
+- family-names: Huckaby
+  given-names: David
+- family-names: Zijlstra
+  given-names: Jelle
+  orcid: 0000-0003-1577-6568
+cff-version: 1.2.0
+date-released: '2024-01-30'
+doi: 10.5281/zenodo.10595931
+keywords:
+- Mammalia
+- Species
+- Diversity
+- Checklist
+- Rodentia
+- Chiroptera
+- Artiodactyla
+- Richness
+- Evolution
+- Ecology
+- Conservation
+license:
+- cc-by-4.0
+title: Mammal Diversity Database
+type: dataset
+version: v1.12.1


### PR DESCRIPTION
Allow to automate releasing `MDD.zip` file to the repository release page. It also releases sha256sum of the file for checking the file integrity after download. The GitHub Action release will be trigger on creating tags. Typical workflow:

```bash
git tag v1.12.1

git push origin --tag
```

Checkout an example in my fork: https://github.com/hhandika/mammaldiversity.github.io/releases