### PR TITLE
Fix IUCN NE status showing empty data.

### DIFF
--- a/js/filter.js
+++ b/js/filter.js
@@ -218,7 +218,7 @@ function renderSpeciesPage(speciesData, permalink) {
 
   var iucnStatus = document.createElement("p");
   var currentIucnStatus = "";
-  if (speciesData.iucnStatus == "NA") {
+  if (speciesData.iucnStatus == "NA" || speciesData.iucnStatus == "NE") {
     currentIucnStatus = "Not evaluated";
   } else if (speciesData.iucnStatus == "DD") {
     currentIucnStatus == "Data deficient";


### PR DESCRIPTION
Fix the issue Connor mentioned on the Slack channel: "I don't know if this was fixed yet, but a while ago on the species sheet, I changed the non-assessed species on the IUCN from 'NA' to 'NE' to reflect the language used by the IUCN for species that haven't been evaluated (they say NE for Not Evaluated). But last time I checked they hadn't shown up on the website."